### PR TITLE
Replaced constant regularisation 1.0 with r

### DIFF
--- a/src/logisticreg.jl
+++ b/src/logisticreg.jl
@@ -73,7 +73,7 @@ end
 function logisticreg_objfun(x::Matrix{Float64}, y::Vector{Float64}, r::Regularizer; 
 	by_columns::Bool=false, bias::Bool=false)
 
-	generic_regress_objfun(LogisticRegressFunctor(), x, y, 1.0; by_columns=by_columns, bias=bias)
+	generic_regress_objfun(LogisticRegressFunctor(), x, y, r; by_columns=by_columns, bias=bias)
 end
 
 function logisticreg(x::Matrix{Float64}, 

--- a/src/mclogisticreg.jl
+++ b/src/mclogisticreg.jl
@@ -121,7 +121,7 @@ end
 function multiclass_logisticreg_objfun(K::Int, x::Matrix{Float64}, y::Vector{Int}, r::Regularizer; 
 	by_columns::Bool=false, bias::Bool=false)
 
-	generic_regress_objfun(MultiClassLogisticRegressFunctor(), K, x, y, 1.0; 
+	generic_regress_objfun(MultiClassLogisticRegressFunctor(), K, x, y, r; 
 		by_columns=by_columns, bias=bias)
 end
 


### PR DESCRIPTION
Both ```logisticreg_objfun``` and ```multiclass_logisticreg_objfun``` were not passing on the regularisation parameters. They were just replacing them with 1.0. I have changed this so that they do pass on the regularisation parameters.