### PR TITLE
Use new value! and predict! methods of Emipircal risks to reduce memory allocation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.3
 Reexport
 Compat 0.4.1
 ArrayViews 0.6.0
-EmpiricalRisks 0.2.3
+EmpiricalRisks 0.2.4

--- a/src/Regression.jl
+++ b/src/Regression.jl
@@ -7,7 +7,7 @@ using ArrayViews
 
 import Base.LinAlg: BlasReal, axpy!
 import Base.LinAlg.LAPACK: gels!, gelsy!, gelsd!
-import EmpiricalRisks: value, value_and_grad!
+import EmpiricalRisks: value, value!, value_and_grad!
 
 export
 	# linearreg


### PR DESCRIPTION
As soon as [PR 7 of EmpiricalRisks.jl](https://github.com/lindahua/EmpiricalRisks.jl/pull/7) is merged and a new version is tagged for EmpiricalRisks.jl, this PR (with the addition of a REQUIRE change) would be able change the `solve!` method to reduce the allocation overhead significantly which also reduces the runtime by half. The issue was discussed [here](https://github.com/lindahua/EmpiricalRisks.jl/issues/6)

Code used for the following benchmark:

```Julia
using EmpiricalRisks
using Regression

d = 3
n = 10000
w = randn(d+1)
X = randn(d, n)
t = sign(X'w[1:d] + w[d+1] + 0.01 * randn(n))

f1 = Regression.RegRiskFun(EmpiricalRisks.riskmodel(EmpiricalRisks.AffinePred(d, 1.), EmpiricalRisks.LogisticLoss()), 
                          Regression.SqrL2Reg(1.0e-2),
                          X, t)
theta = zeros(d+1)

@time Regression.solve!(Regression.GD(), f1, theta,
                    Regression.Options(maxiter = 100),
                    Regression.no_op)
@time Regression.solve!(Regression.GD(), f1, theta,
                    Regression.Options(maxiter = 10000),
                    Regression.no_op)
```

Old (Status Quo without this PR):
```
elapsed time: 1.737362195 seconds (103040628 bytes allocated, 3.41% gc time)
elapsed time: 20.363554074 seconds (1432350168 bytes allocated, 5.96% gc time)
```

New (with this PR):
```
elapsed time: 1.0107789 seconds (27390472 bytes allocated, 2.54% gc time)
elapsed time: 7.516005746 seconds (783976 bytes allocated)

```