### PR TITLE
add prediction model to Solution to enable predict on it

### DIFF
--- a/src/Regression.jl
+++ b/src/Regression.jl
@@ -7,7 +7,7 @@ using ArrayViews
 
 import Base.LinAlg: BlasReal, axpy!
 import Base.LinAlg.LAPACK: gels!, gelsy!, gelsd!
-import EmpiricalRisks: value, value!, value_and_grad!
+import EmpiricalRisks: value, value!, value_and_grad!, predict
 
 export
 	# linearreg

--- a/src/optimbase.jl
+++ b/src/optimbase.jl
@@ -102,15 +102,21 @@ end
 
 ### Solution
 
-immutable Solution{Sol<:StridedArray}
+immutable Solution{PM<:PredictionModel,Sol<:StridedArray}
+    predmodel::PM
     sol::Sol
     fval::Float64
     niters::Int
     converged::Bool
 end
 
+function predict{S<:Solution, T<:BlasReal}(solution::S, X::StridedMatrix{T})
+    predict(solution.predmodel, solution.sol, X)
+end
+
 function Base.show(io::IO, r::Solution)
     println(io, "RiskMinSolution:")
+    println(io, "- predmodel: $(typeof(r.predmodel))")
     println(io, "- sol:       $(size(r.sol)) $(typeof(r.sol))")
     println(io, "- fval:      $(r.fval)")
     println(io, "- niters:    $(r.niters)")

--- a/src/proxsolve.jl
+++ b/src/proxsolve.jl
@@ -26,14 +26,14 @@ function _solve{T<:FloatingPoint}(
     if has_bias(pb)
         rmodel = riskmodel(pred_with_bias(pb), loss(pb))
         f = RiskFun(rmodel, inputs(pb), outputs(pb))
-        solve!(solver, f, reg, θ, options, callback)
+        solve!(solver, f, reg, θ, options, callback)::Solution{typeof(rmodel.predmodel),typeof(θ)}
 
     else
         rmodel = riskmodel(pred_without_bias(pb), loss(pb))
         f = RiskFun(rmodel, inputs(pb), outputs(pb))
-        solve!(solver, f, reg, θ, options, callback)
+        solve!(solver, f, reg, θ, options, callback)::Solution{typeof(rmodel.predmodel),typeof(θ)}
 
-    end::Solution{typeof(θ)}
+    end
 end
 
 
@@ -127,5 +127,5 @@ function solve!{T<:FloatingPoint}(solver::ProximalDescent,
         print_final(t, v, converged)
     end
 
-    return Solution(θ, v, t, converged)
+    return Solution(f.rmodel.predmodel, θ, v, t, converged)
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -13,14 +13,14 @@ function _solve{T<:FloatingPoint}(
     if has_bias(pb)
         rmodel = riskmodel(pred_with_bias(pb), loss(pb))
         f = RegRiskFun(rmodel, reg, inputs(pb), outputs(pb))
-        solve!(solver, f, θ, options, callback)
+        solve!(solver, f, θ, options, callback)::Solution{typeof(rmodel.predmodel),typeof(θ)}
 
     else
         rmodel = riskmodel(pred_without_bias(pb), loss(pb))
         f = RegRiskFun(rmodel, reg, inputs(pb), outputs(pb))
-        solve!(solver, f, θ, options, callback)
+        solve!(solver, f, θ, options, callback)::Solution{typeof(rmodel.predmodel),typeof(θ)}
 
-    end::Solution{typeof(θ)}
+    end
 end
 
 function solve{T<:FloatingPoint}(
@@ -110,7 +110,7 @@ function solve!{T<:FloatingPoint}(solver::DescentSolver,
         print_final(t, v, converged)
     end
 
-    return Solution(θ, v, t, converged)
+    return Solution(f.rmodel.predmodel, θ, v, t, converged)
 end
 
 

--- a/test/solve.jl
+++ b/test/solve.jl
@@ -31,6 +31,11 @@ function verify_solver(title, loss::Loss, data,
     b = dθ == dx ? 0.0 :
         dθ == dx + 1 ? 1.0 :
         error("Unmatched dimensions.")
+    pm = if ndims(θg) == 1
+        b == 1. ? AffinePred(dx, b) : LinearPred(dx)
+    else
+        b == 1. ? MvAffinePred(dx, size(θg,1), b) : MvLinearPred(dx, size(θg,1))
+    end
 
     pb = ndims(θg) == 1 ? UnivariateRegression(loss, data...; bias=b) :
                           MultivariateRegression(loss, data...; bias=b)
@@ -45,6 +50,7 @@ function verify_solver(title, loss::Loss, data,
 
         @test isa(ret, Regression.Solution)
         θe = ret.sol
+        @test predict(pm, θe, X) == predict(ret, X)
         @test vcond(θe, θg) < thres
     end
 end


### PR DESCRIPTION
This essentially stores the prediction model in the fit solution as well. This will make my life a lot easier in KSVM.jl to predict things. Otherwise I'd have to break the compatibility of KSVM and Regression.jl

It essentially allows the last line of this code

```Julia
d = 3      # sample dimension
n = 1000   # number of samples

# prepare data
w = randn(d+1)    # generate the weight vector
X = randn(d, n)   # generate input features
y = sign(X'w[1:d] + w[d+1] + 0.2 * randn(n))  # generate (noisy) response

# perform estimation
ret = Regression.solve(
    logisticreg(X, y; bias=1.0),   # construct a logistic regression problem
    reg=SqrL2Reg(1.0e-2),          # apply squared L2 regularization
    options=Options(verbosity=:iter, grtol=1.0e-6 * n))  # set options

yhat = sign(predict(ret, X))
```